### PR TITLE
Fixes for failing composable recorder tests after rebase

### DIFF
--- a/rosbag2_transport/src/rosbag2_transport/config_options_from_node_params.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/config_options_from_node_params.cpp
@@ -204,13 +204,17 @@ PlayOptions get_play_options_from_node_params(rclcpp::Node & node)
 RecordOptions get_record_options_from_node_params(rclcpp::Node & node)
 {
   RecordOptions record_options{};
-  record_options.all = node.declare_parameter<bool>("record.all", false);
+  record_options.all_topics = node.declare_parameter<bool>("record.all_topics", false);
+  record_options.all_services = node.declare_parameter<bool>("record.all_services", false);
 
   record_options.is_discovery_disabled =
     node.declare_parameter<bool>("record.is_discovery_disabled", false);
 
   record_options.topics = node.declare_parameter<std::vector<std::string>>(
     "record.topics", std::vector<std::string>());
+
+  record_options.services = node.declare_parameter<std::vector<std::string>>(
+    "record.services", std::vector<std::string>());
 
   record_options.rmw_serialization_format =
     node.declare_parameter<std::string>("record.rmw_serialization_format", "cdr");
@@ -220,7 +224,7 @@ RecordOptions get_record_options_from_node_params(rclcpp::Node & node)
     0, 1000000).to_chrono<std::chrono::milliseconds>();
 
   record_options.regex = node.declare_parameter<std::string>("record.regex", "");
-  record_options.exclude = node.declare_parameter<std::string>("record.exclude", "");
+  record_options.exclude_regex = node.declare_parameter<std::string>("record.exclude_regex", "");
   record_options.node_prefix = node.declare_parameter<std::string>("record.node_prefix", "");
   record_options.compression_mode = node.declare_parameter<std::string>(
     "record.compression_mode",

--- a/rosbag2_transport/src/rosbag2_transport/recorder.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/recorder.cpp
@@ -183,8 +183,12 @@ RecorderImpl::RecorderImpl(
 
   for (auto & topic : record_options_.topics) {
     topic = rclcpp::expand_topic_or_service_name(
-      topic, node->get_name(),
-      node->get_namespace(), false);
+      topic, node->get_name(), node->get_namespace(), false);
+  }
+
+  for (auto & service : record_options_.services) {
+    service = rclcpp::expand_topic_or_service_name(
+      service, node->get_name(), node->get_namespace(), true);
   }
 }
 

--- a/rosbag2_transport/test/resources/recorder_node_params.yaml
+++ b/rosbag2_transport/test/resources/recorder_node_params.yaml
@@ -4,15 +4,17 @@ recorder_params_node:
     use_sim_time: false
 
     record:
-      all: true
+      all_topics: true
+      all_services: true
       is_discovery_disabled: true
       topics: ["topic", "other_topic"]
+      services: ["service", "other_service"]
       rmw_serialization_format: "cdr"
       topic_polling_interval:
         sec: 0
         nsec: 10000000
       regex: "[xyz]/topic"
-      exclude: "*"
+      exclude_regex: "*"
       node_prefix: "prefix"
       compression_mode: "stream"
       compression_format: "h264"

--- a/rosbag2_transport/test/resources/recorder_node_params.yaml
+++ b/rosbag2_transport/test/resources/recorder_node_params.yaml
@@ -14,7 +14,7 @@ recorder_params_node:
         sec: 0
         nsec: 10000000
       regex: "[xyz]/topic"
-      exclude_regex: "*"
+      exclude_regex: "(.*)"
       node_prefix: "prefix"
       compression_mode: "stream"
       compression_format: "h264"

--- a/rosbag2_transport/test/rosbag2_transport/test_composable_recorder.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_composable_recorder.cpp
@@ -217,7 +217,7 @@ TEST_P(ComposableRecorderTests, recorder_can_parse_parameters_from_file) {
   EXPECT_EQ(record_options.rmw_serialization_format, "cdr");
   EXPECT_TRUE(record_options.topic_polling_interval == 0.01s);
   EXPECT_EQ(record_options.regex, "[xyz]/topic");
-  EXPECT_EQ(record_options.exclude_regex, "*");
+  EXPECT_EQ(record_options.exclude_regex, "(.*)");
   EXPECT_EQ(record_options.node_prefix, "prefix");
   EXPECT_EQ(record_options.compression_mode, "stream");
   EXPECT_EQ(record_options.compression_format, "h264");

--- a/rosbag2_transport/test/rosbag2_transport/test_composable_recorder.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_composable_recorder.cpp
@@ -207,14 +207,17 @@ TEST_P(ComposableRecorderTests, recorder_can_parse_parameters_from_file) {
   auto record_options = recorder->get_record_options();
   auto storage_options = recorder->get_storage_options();
 
-  EXPECT_EQ(record_options.all, true);
+  EXPECT_EQ(record_options.all_topics, true);
+  EXPECT_EQ(record_options.all_services, true);
   EXPECT_EQ(record_options.is_discovery_disabled, true);
   std::vector<std::string> topics {"/topic", "/other_topic"};
   EXPECT_EQ(record_options.topics, topics);
+  std::vector<std::string> services {"/service", "/other_service"};
+  EXPECT_EQ(record_options.services, services);
   EXPECT_EQ(record_options.rmw_serialization_format, "cdr");
   EXPECT_TRUE(record_options.topic_polling_interval == 0.01s);
   EXPECT_EQ(record_options.regex, "[xyz]/topic");
-  EXPECT_EQ(record_options.exclude, "*");
+  EXPECT_EQ(record_options.exclude_regex, "*");
   EXPECT_EQ(record_options.node_prefix, "prefix");
   EXPECT_EQ(record_options.compression_mode, "stream");
   EXPECT_EQ(record_options.compression_format, "h264");


### PR DESCRIPTION
- Relates to the https://github.com/ros2/rosbag2/pull/1480

- Fixed regex pattern in tests. Use ""(.*)"" instead "*".
- Apply rclcpp::expand_topic_or_service_name(..) for service in the recorder constructor
