### PR TITLE
Make get_full_text(..) with action and service introspection API/ABI compatible

### DIFF
--- a/rosbag2_cpp/include/rosbag2_cpp/message_definitions/local_message_definition_source.hpp
+++ b/rosbag2_cpp/include/rosbag2_cpp/message_definitions/local_message_definition_source.hpp
@@ -68,7 +68,30 @@ public:
    * Throws DefinitionNotFoundError if one or more definition files are missing for the given
    * package resource name.
    */
-  rosbag2_storage::MessageDefinition get_full_text(
+  [[deprecated("Use get_full_text_ext() instead, which allows specifying the topic name and "
+     "provides more flexibility in how the message definition is constructed.")]]
+   // TODO(Barry-Xu): Replace all calls to this function with get_full_text_ext()
+  rosbag2_storage::MessageDefinition get_full_text(const std::string & root_type);
+
+  /**
+   * \brief Concatenate the message definition with its dependencies into a self-contained schema.
+   * \details The format is different for MSG/SRV/ACTION and IDL definitions, and is described
+   * fully in the docs/message_definition_encoding.md.
+   * For SRV type, root_type must include a string '/srv/'.
+   * For ACTION type, root_type must include a string '/action/'.
+   * Note: that for service or action introspection topics, the topic type will be extended to the
+   * inner original service or action type, respectively, before trying to find the
+   * message definition.
+   * \param[in] topic_name The topic name, which is used to determine the message definition format.
+   * \param[in] root_type The root type of the message definition, which should be a fully qualified
+   * datatype name.
+   * \throws DefinitionNotFoundError if one or more definition files are missing for the given
+   * package resource name.
+   * \return A MessageDefinition object containing the encoded message definition and its
+   * dependencies.
+   */
+  // TODO(Barry-Xu): Change the order of parameters to match the order in get_full_text()
+  rosbag2_storage::MessageDefinition get_full_text_ext(
     const std::string & topic_name,
     const std::string & root_type);
 

--- a/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
@@ -27,6 +27,7 @@
 #include <ament_index_cpp/get_package_prefix.hpp>
 
 #include "rosbag2_cpp/action_utils.hpp"
+#include "rosbag2_cpp/service_utils.hpp"
 #include "rosbag2_cpp/logging.hpp"
 
 namespace rosbag2_cpp
@@ -225,6 +226,12 @@ const LocalMessageDefinitionSource::MessageSpec & LocalMessageDefinitionSource::
 }
 
 rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text(
+  const std::string & root_type)
+{
+  return get_full_text_ext(std::string{}, root_type);
+}
+
+rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text_ext(
   const std::string & topic_name,
   const std::string & root_type)
 {
@@ -256,9 +263,10 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text(
   Format format = Format::UNKNOWN;
   int32_t max_recursion_depth = ROSBAG2_CPP_LOCAL_MESSAGE_DEFINITION_SOURCE_MAX_RECURSION_DEPTH;
 
-  bool is_action_type = is_topic_belong_to_action(topic_name, root_type);
+  bool is_action_type = root_type.find("/action/") != std::string::npos;
+  bool is_service_type = (!is_action_type && root_type.find("/srv/") != std::string::npos);
 
-  if (root_type.find("/srv/") == std::string::npos && !is_action_type) {  // Only msg and idl files
+  if (!is_service_type && !is_action_type) {  // Only msg and idl files
     try {
       format = Format::MSG;
       result = append_recursive(DefinitionIdentifier(root_type, format), max_recursion_depth);
@@ -279,20 +287,18 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text(
     // Therefore, will try to search dependencies in MSG files first then in IDL files
     // via two separate recursive searches for each dependency.
     format = Format::UNKNOWN;
-    if (root_type.find("/srv/") != std::string::npos &&
-      !is_action_type)
-    {
+    if (is_service_type) {
       format = Format::SRV;
-
-      // Convert service event type to service type
-      std::regex srv_event_type_postfix_regex{R"(_Event$)"};
-      if (std::regex_search(root_type, srv_event_type_postfix_regex)) {
-        real_root_type = std::regex_replace(
-          root_type, srv_event_type_postfix_regex, "");
+      if (!topic_name.empty() && is_service_event_topic(topic_name, root_type)) {
+        // Convert service event type to service type
+        real_root_type = service_event_topic_type_to_service_type(root_type);
       }
     } else if (is_action_type) {
       format = Format::ACTION;
-      real_root_type = action_interface_name_to_action_name(topic_name);
+      if (!topic_name.empty() && is_topic_belong_to_action(topic_name, root_type)) {
+        // Convert action interface type to action type
+        real_root_type = rosbag2_cpp::get_action_type_for_info(root_type);
+      }
     }
     DefinitionIdentifier def_identifier{real_root_type, format};
     (void)seen_deps.insert(def_identifier).second;
@@ -334,6 +340,7 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text(
       break;
     case Format::MSG:
     case Format::SRV:
+    case Format::ACTION:
       out.encoding = "ros2msg";
       break;
     case Format::IDL:

--- a/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/message_definitions/local_message_definition_source.cpp
@@ -263,7 +263,10 @@ rosbag2_storage::MessageDefinition LocalMessageDefinitionSource::get_full_text_e
   Format format = Format::UNKNOWN;
   int32_t max_recursion_depth = ROSBAG2_CPP_LOCAL_MESSAGE_DEFINITION_SOURCE_MAX_RECURSION_DEPTH;
 
-  bool is_action_type = root_type.find("/action/") != std::string::npos;
+  bool is_action_type =
+    root_type.find("/action/") != std::string::npos ||
+    root_type == "action_msgs/msg/GoalStatusArray" ||
+    root_type == "action_msgs/srv/CancelGoal_Event";
   bool is_service_type = (!is_action_type && root_type.find("/srv/") != std::string::npos);
 
   if (!is_service_type && !is_action_type) {  // Only msg and idl files

--- a/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
+++ b/rosbag2_cpp/src/rosbag2_cpp/writers/sequential_writer.cpp
@@ -221,7 +221,7 @@ void SequentialWriter::create_topic(const rosbag2_storage::TopicMetadata & topic
   }
   rosbag2_storage::MessageDefinition definition;
   try {
-    definition = message_definitions_.get_full_text(topic_with_type.name, topic_with_type.type);
+    definition = message_definitions_.get_full_text_ext(topic_with_type.name, topic_with_type.type);
   } catch (DefinitionNotFoundError &) {
     definition =
       rosbag2_storage::MessageDefinition::empty_message_definition_for(topic_with_type.type);

--- a/rosbag2_cpp/test/rosbag2_cpp/test_local_message_definition_source.cpp
+++ b/rosbag2_cpp/test/rosbag2_cpp/test_local_message_definition_source.cpp
@@ -51,7 +51,7 @@ module rosbag2_test_msgdefs {
 TEST(test_local_message_definition_source, can_find_msg_deps)
 {
   LocalMessageDefinitionSource source;
-  auto result = source.get_full_text("/complex_msg_topic", "rosbag2_test_msgdefs/ComplexMsg");
+  auto result = source.get_full_text_ext("/complex_msg_topic", "rosbag2_test_msgdefs/ComplexMsg");
   ASSERT_EQ(result.encoding, "ros2msg");
   ASSERT_EQ(
     result.encoded_message_definition,
@@ -65,7 +65,7 @@ TEST(test_local_message_definition_source, can_find_msg_deps)
 TEST(test_local_message_definition_source, can_find_srv_deps_in_msg)
 {
   LocalMessageDefinitionSource source;
-  auto result = source.get_full_text("/complex_srv_msg_topic/_service_event",
+  auto result = source.get_full_text_ext("/complex_srv_msg_topic/_service_event",
     "rosbag2_test_msgdefs/srv/ComplexSrvMsg_Event");
   ASSERT_EQ(result.encoding, "ros2msg");
   ASSERT_EQ(
@@ -84,7 +84,7 @@ TEST(test_local_message_definition_source, can_find_srv_deps_in_msg)
 TEST(test_local_message_definition_source, can_find_srv_deps_in_idl)
 {
   LocalMessageDefinitionSource source;
-  auto result = source.get_full_text("/complex_srv_idl_topic/_service_event",
+  auto result = source.get_full_text_ext("/complex_srv_idl_topic/_service_event",
     "rosbag2_test_msgdefs/srv/ComplexSrvIdl_Event");
   ASSERT_EQ(result.encoding, "ros2idl");
   ASSERT_EQ(

--- a/rosbag2_py/src/rosbag2_py/_message_definitions.cpp
+++ b/rosbag2_py/src/rosbag2_py/_message_definitions.cpp
@@ -23,5 +23,7 @@ PYBIND11_MODULE(_message_definitions, m) {
     m, "LocalMessageDefinitionSource")
   .def(pybind11::init<>())
   .def(
-    "get_full_text", &rosbag2_cpp::LocalMessageDefinitionSource::get_full_text);
+    "get_full_text", &rosbag2_cpp::LocalMessageDefinitionSource::get_full_text)
+  .def(
+    "get_full_text_ext", &rosbag2_cpp::LocalMessageDefinitionSource::get_full_text_ext);
 }

--- a/rosbag2_py/test/test_message_definitions.py
+++ b/rosbag2_py/test/test_message_definitions.py
@@ -17,7 +17,7 @@ from rosbag2_py import LocalMessageDefinitionSource
 
 def test_local_message_definition_source_no_crash_on_bad_name():
     source = LocalMessageDefinitionSource()
-    result = source.get_full_text('some_topic', 'some_pkg')
+    result = source.get_full_text_ext('some_topic', 'some_pkg')
     assert result.encoding == 'unknown'
     assert result.encoded_message_definition == ''
     assert result.topic_type == 'some_pkg'
@@ -25,7 +25,7 @@ def test_local_message_definition_source_no_crash_on_bad_name():
 
 def test_local_message_definition_source_can_find_msg_deps():
     source = LocalMessageDefinitionSource()
-    result = source.get_full_text('/complex_msg', 'rosbag2_test_msgdefs/ComplexMsg')
+    result = source.get_full_text_ext('/complex_msg', 'rosbag2_test_msgdefs/ComplexMsg')
     assert result.encoding == 'ros2msg'
     assert result.encoded_message_definition == (
         'rosbag2_test_msgdefs/BasicMsg b\n'
@@ -38,7 +38,7 @@ def test_local_message_definition_source_can_find_msg_deps():
 
 def test_local_message_definition_source_can_find_srv_deps_in_msg():
     source = LocalMessageDefinitionSource()
-    result = source.get_full_text('/complex_msg', 'rosbag2_test_msgdefs/srv/ComplexSrvMsg')
+    result = source.get_full_text_ext('/complex_msg', 'rosbag2_test_msgdefs/srv/ComplexSrvMsg')
     assert result.encoding == 'ros2msg'
     assert result.topic_type == 'rosbag2_test_msgdefs/srv/ComplexSrvMsg'
     assert result.encoded_message_definition == (
@@ -56,7 +56,7 @@ def test_local_message_definition_source_can_find_srv_deps_in_msg():
 
 def test_local_message_definition_source_can_find_srv_deps_in_idl():
     source = LocalMessageDefinitionSource()
-    result = source.get_full_text('/complex_msg', 'rosbag2_test_msgdefs/srv/ComplexSrvIdl')
+    result = source.get_full_text_ext('/complex_msg', 'rosbag2_test_msgdefs/srv/ComplexSrvIdl')
     assert result.encoding == 'ros2idl'
     assert result.topic_type == 'rosbag2_test_msgdefs/srv/ComplexSrvIdl'
     assert result.encoded_message_definition == (


### PR DESCRIPTION
This PR adds a new `get_full_text_ext(topic_name, topic_type)` to avoid API/ABI breaking changes in the original `get_full_text(topic_type)` with action and service introspection.

Also, some cleanups and make sure that the original newly added `get_full_text_ext(topic_name, topic_type)`  API has backward compatibility with the original `get_full_text(topic_type)` if `topic_name` is not specified.
